### PR TITLE
Internal Api Refactor

### DIFF
--- a/gateway/src/main/java/com/github/matkubiak/taskplanner/gateway/GatewayApplication.java
+++ b/gateway/src/main/java/com/github/matkubiak/taskplanner/gateway/GatewayApplication.java
@@ -35,6 +35,11 @@ public class GatewayApplication {
 						.filters(f -> f.rewritePath("/api/auth/(?<segment>.*)", "/${segment}"))
 						.uri("http://user-service:8080/"))
 
+				.route("task-health", r -> r
+					.path("/api/tasks/health")
+					.filters(f -> f.setPath("/health"))
+					.uri("http://task-service:8080"))
+
 				.route("tasks", r -> r
 						.path("/api/tasks/**")
 						.filters(f -> f

--- a/gateway/src/main/java/com/github/matkubiak/taskplanner/gateway/GatewayApplication.java
+++ b/gateway/src/main/java/com/github/matkubiak/taskplanner/gateway/GatewayApplication.java
@@ -24,18 +24,6 @@ public class GatewayApplication {
 	@Bean
 	public RouteLocator myRoutes(RouteLocatorBuilder builder) {
 		return builder.routes()
-				.route(p -> p
-						.path("/api/tasks")
-						.uri("http://task-service:8080/api/tasks/"))
-				.route(p -> p
-						.path("/api/tasks/health")
-						.uri("http://task-service:8080/api/tasks/health"))
-				.route(p -> p
-						.path("/api/users")
-						.uri("http://user-service:8080/api/users/"))
-				.route(p -> p
-						.path("/api/users/health")
-						.uri("http://user-service:8080/api/users/health"))
 				.build();
 	}
 

--- a/gateway/src/main/java/com/github/matkubiak/taskplanner/gateway/GatewayApplication.java
+++ b/gateway/src/main/java/com/github/matkubiak/taskplanner/gateway/GatewayApplication.java
@@ -8,14 +8,20 @@
 
 package com.github.matkubiak.taskplanner.gateway;
 
+import com.github.matkubiak.taskplanner.gateway.filters.JwtAuthorizationFilter;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.gateway.filter.GatewayFilter;
 import org.springframework.cloud.gateway.route.RouteLocator;
 import org.springframework.cloud.gateway.route.builder.RouteLocatorBuilder;
 import org.springframework.context.annotation.Bean;
 
 @SpringBootApplication
 public class GatewayApplication {
+
+	@Autowired
+	private GatewayFilter jwtAuthorizationFilter;
 
 	public static void main(String[] args) {
 		SpringApplication.run(GatewayApplication.class, args);
@@ -28,6 +34,14 @@ public class GatewayApplication {
 						.path("/api/auth/**")
 						.filters(f -> f.rewritePath("/api/auth/(?<segment>.*)", "/${segment}"))
 						.uri("http://user-service:8080/"))
+
+				.route("tasks", r -> r
+						.path("/api/tasks/**")
+						.filters(f -> f
+								.rewritePath("/api/tasks/(?<segment>.*)", "/${segment}")
+								.filter(jwtAuthorizationFilter))
+						.uri("http://task-service:8080"))
+
 				.build();
 	}
 

--- a/gateway/src/main/java/com/github/matkubiak/taskplanner/gateway/GatewayApplication.java
+++ b/gateway/src/main/java/com/github/matkubiak/taskplanner/gateway/GatewayApplication.java
@@ -24,6 +24,10 @@ public class GatewayApplication {
 	@Bean
 	public RouteLocator myRoutes(RouteLocatorBuilder builder) {
 		return builder.routes()
+				.route("auth", r -> r
+						.path("/api/auth/**")
+						.filters(f -> f.rewritePath("/api/auth/(?<segment>.*)", "/${segment}"))
+						.uri("http://user-service:8080/"))
 				.build();
 	}
 

--- a/gateway/src/main/java/com/github/matkubiak/taskplanner/gateway/GatewayApplication.java
+++ b/gateway/src/main/java/com/github/matkubiak/taskplanner/gateway/GatewayApplication.java
@@ -30,6 +30,11 @@ public class GatewayApplication {
 	@Bean
 	public RouteLocator myRoutes(RouteLocatorBuilder builder) {
 		return builder.routes()
+				.route("auth-health", r -> r
+						.path("/api/auth/health")
+						.filters(f -> f.setPath("/health"))
+						.uri("http://user-service:8080"))
+
 				.route("auth", r -> r
 						.path("/api/auth/**")
 						.filters(f -> f.rewritePath("/api/auth/(?<segment>.*)", "/${segment}"))

--- a/services/task-service/src/main/java/com/github/matkubiak/taskplanner/controller/TaskController.java
+++ b/services/task-service/src/main/java/com/github/matkubiak/taskplanner/controller/TaskController.java
@@ -26,24 +26,24 @@ public class TaskController {
     @Autowired
     private TaskService taskService;
 
-    @GetMapping(path="/health")
+    @GetMapping("/health")
     public ResponseEntity<Object> healthCheck() {
         return new ResponseEntity<>("Service is up and running!", HttpStatus.OK);
     }
 
-    @GetMapping(path="/")
+    @GetMapping("/")
     public ResponseEntity<List<Task>> getTasks() {
         List<Task> tasks = taskService.getAllTasks();
         return new ResponseEntity<>(tasks, HttpStatus.OK);
     }
 
-    @PostMapping(path="/")
+    @PostMapping("/")
     public ResponseEntity<Object> createTask(@RequestBody TaskCreateDTO taskDto) {
         taskService.saveTask(taskDto);
         return new ResponseEntity<>("Task created successfully", HttpStatus.CREATED);
     }
 
-    @DeleteMapping(path="/{taskId}")
+    @DeleteMapping("/{taskId}")
     public ResponseEntity<Object> deleteTask(@PathVariable(name="taskId") Long taskId) {
         try {
             taskService.deleteTask(taskId);
@@ -53,7 +53,7 @@ public class TaskController {
         return new ResponseEntity<>("Task deleted successfully", HttpStatus.ACCEPTED);
     }
 
-    @PutMapping(path="/")
+    @PutMapping("/")
     public ResponseEntity<Object> updateTask(@RequestBody TaskUpdateDTO taskDto) {
         try {
             taskService.updateTask(taskDto);

--- a/services/task-service/src/main/resources/application.properties
+++ b/services/task-service/src/main/resources/application.properties
@@ -5,5 +5,3 @@ spring.datasource.username=${MYSQLDB_USER}
 spring.datasource.password=${MYSQLDB_ROOT_PASSWORD}
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQLDialect
 spring.jpa.hibernate.ddl-auto=update
-
-server.servlet.contextPath=/api/tasks/

--- a/services/user-service/src/main/java/com/github/matkubiak/taskplanner/controller/AuthenticationController.java
+++ b/services/user-service/src/main/java/com/github/matkubiak/taskplanner/controller/AuthenticationController.java
@@ -17,11 +17,9 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/")
 public class AuthenticationController {
 
     @Autowired

--- a/services/user-service/src/main/java/com/github/matkubiak/taskplanner/controller/AuthenticationController.java
+++ b/services/user-service/src/main/java/com/github/matkubiak/taskplanner/controller/AuthenticationController.java
@@ -15,6 +15,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.AuthenticationException;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
@@ -27,6 +28,11 @@ public class AuthenticationController {
 
     @Autowired
     private AuthenticationService authenticationService;
+
+    @GetMapping("/health")
+    public ResponseEntity<Object> healthCheck() {
+        return new ResponseEntity<>("Service is up and running!", HttpStatus.OK);
+    }
 
     @PostMapping("/signup")
     public ResponseEntity<String> register(@RequestBody RegisterDTO dto) {

--- a/services/user-service/src/main/java/com/github/matkubiak/taskplanner/controller/AuthenticationController.java
+++ b/services/user-service/src/main/java/com/github/matkubiak/taskplanner/controller/AuthenticationController.java
@@ -21,7 +21,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/auth")
+@RequestMapping("/")
 public class AuthenticationController {
 
     @Autowired

--- a/services/user-service/src/main/resources/application.properties
+++ b/services/user-service/src/main/resources/application.properties
@@ -6,7 +6,5 @@ spring.datasource.password=${MYSQLDB_ROOT_PASSWORD}
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQLDialect
 spring.jpa.hibernate.ddl-auto=update
 
-server.servlet.contextPath=/api/users/
-
 security.jwt.secret-key=${JWT_SECRET}
 security.jwt.expiration-time=${JWT_EXPIRATION}


### PR DESCRIPTION
This PR simplifies internal API of the application. Resource paths of individual service API have been shortened, and a new generalized routing system simplified process of adding new endpoints. Additionally, the new authorization filter has been used to authorize task-related requests.

### Example

An example of request routing before this PR:

> GET `/api/auth/login` -> GET `user-service/api/auth/login`

and now after this PR:

> GET `/api/auth/login` -> GET `user-service/login`

### Changelog

API:
* [internal] removed contex path from service APIs
* added unauthorized health check for authorization service: GET `/api/auth/health`
* set up jwt authorization filter for `/api/tasks/**` resources

Features:
* introduced a more general routing system which automatically covers all new endpoints