### PR TITLE
Update JWT Service

### DIFF
--- a/services/user-service/pom.xml
+++ b/services/user-service/pom.xml
@@ -75,17 +75,17 @@
 		<dependency>
 			<groupId>io.jsonwebtoken</groupId>
 			<artifactId>jjwt-api</artifactId>
-			<version>0.11.5</version>
+			<version>0.12.6</version>
 		</dependency>
 		<dependency>
 			<groupId>io.jsonwebtoken</groupId>
 			<artifactId>jjwt-impl</artifactId>
-			<version>0.11.5</version>
+			<version>0.12.6</version>
 		</dependency>
 		<dependency>
 			<groupId>io.jsonwebtoken</groupId>
 			<artifactId>jjwt-jackson</artifactId>
-			<version>0.11.5</version>
+			<version>0.12.6</version>
 		</dependency>
 	</dependencies>
 

--- a/services/user-service/src/main/java/com/github/matkubiak/taskplanner/model/ExtendedUserDetails.java
+++ b/services/user-service/src/main/java/com/github/matkubiak/taskplanner/model/ExtendedUserDetails.java
@@ -1,0 +1,16 @@
+/*
+ * Task Planner
+ * Copyright (C) Mateusz Kubiak
+ *
+ * Licensed under the GNU General Public License v3.
+ * See LICENSE or visit <https://www.gnu.org/licenses/>.
+ */
+
+package com.github.matkubiak.taskplanner.model;
+
+import org.springframework.security.core.userdetails.UserDetails;
+
+public interface ExtendedUserDetails extends UserDetails {
+
+    Long getId();
+}

--- a/services/user-service/src/main/java/com/github/matkubiak/taskplanner/model/User.java
+++ b/services/user-service/src/main/java/com/github/matkubiak/taskplanner/model/User.java
@@ -12,13 +12,12 @@ import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import org.hibernate.validator.constraints.Length;
 import org.springframework.security.core.GrantedAuthority;
-import org.springframework.security.core.userdetails.UserDetails;
 
 import java.util.Collection;
 import java.util.List;
 
 @Entity
-public class User implements UserDetails {
+public class User implements ExtendedUserDetails {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -63,6 +62,11 @@ public class User implements UserDetails {
     @Override
     public String getUsername() {
         return email;
+    }
+
+    @Override
+    public Long getId() {
+        return userId;
     }
 
     @Override

--- a/services/user-service/src/main/java/com/github/matkubiak/taskplanner/service/JwtService.java
+++ b/services/user-service/src/main/java/com/github/matkubiak/taskplanner/service/JwtService.java
@@ -8,12 +8,12 @@
 
 package com.github.matkubiak.taskplanner.service;
 
+import com.github.matkubiak.taskplanner.model.ExtendedUserDetails;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.io.Decoders;
 import java.util.Date;
 
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
 
 import javax.crypto.SecretKey;
@@ -36,9 +36,9 @@ public class JwtService {
         return jwtExpiration;
     }
 
-    public String generateToken(UserDetails userDetails) {
+    public String generateToken(ExtendedUserDetails userDetails) {
         return Jwts.builder()
-            .subject(userDetails.getUsername())
+            .subject(String.valueOf(userDetails.getId()))
             .issuedAt(new Date(System.currentTimeMillis()))
             .expiration(new Date(System.currentTimeMillis() + jwtExpiration))
             .signWith(secretKey)

--- a/services/user-service/src/main/java/com/github/matkubiak/taskplanner/service/JwtService.java
+++ b/services/user-service/src/main/java/com/github/matkubiak/taskplanner/service/JwtService.java
@@ -8,89 +8,42 @@
 
 package com.github.matkubiak.taskplanner.service;
 
-import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.io.Decoders;
-import io.jsonwebtoken.security.Keys;
-import java.security.Key;
 import java.util.Date;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.function.Function;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
 
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+
 @Service
 public class JwtService {
-    @Value("${security.jwt.secret-key}")
-    private String secretKey;
 
     @Value("${security.jwt.expiration-time}")
     private long jwtExpiration;
 
-    public String extractUsername(String token) {
-        return extractClaim(token, Claims::getSubject);
-    }
+    private final SecretKey secretKey;
 
-    public <T> T extractClaim(String token, Function<Claims, T> claimsResolver) {
-        final Claims claims = extractAllClaims(token);
-        return claimsResolver.apply(claims);
-    }
-
-    public String generateToken(UserDetails userDetails) {
-        return generateToken(new HashMap<>(), userDetails);
-    }
-
-    public String generateToken(Map<String, Object> extraClaims, UserDetails userDetails) {
-        return buildToken(extraClaims, userDetails, jwtExpiration);
+    public JwtService(@Value("${security.jwt.secret-key}") String secretKeyBase64) {
+        byte[] decodedKey = Decoders.BASE64.decode(secretKeyBase64);
+        secretKey = new SecretKeySpec(decodedKey, 0, decodedKey.length, "HmacSHA256");
     }
 
     public long getExpirationTime() {
         return jwtExpiration;
     }
 
-    private String buildToken(
-            Map<String, Object> extraClaims,
-            UserDetails userDetails,
-            long expiration
-    ) {
+    public String generateToken(UserDetails userDetails) {
         return Jwts
                 .builder()
-                .setClaims(extraClaims)
                 .setSubject(userDetails.getUsername())
                 .setIssuedAt(new Date(System.currentTimeMillis()))
-                .setExpiration(new Date(System.currentTimeMillis() + expiration))
-                .signWith(getSignInKey(), SignatureAlgorithm.HS256)
+                .setExpiration(new Date(System.currentTimeMillis() + jwtExpiration))
+                .signWith(secretKey, SignatureAlgorithm.HS256)
                 .compact();
-    }
-
-    public boolean isTokenValid(String token, UserDetails userDetails) {
-        final String username = extractUsername(token);
-        return (username.equals(userDetails.getUsername())) && !isTokenExpired(token);
-    }
-
-    private boolean isTokenExpired(String token) {
-        return extractExpiration(token).before(new Date());
-    }
-
-    private Date extractExpiration(String token) {
-        return extractClaim(token, Claims::getExpiration);
-    }
-
-    private Claims extractAllClaims(String token) {
-        return Jwts
-                .parserBuilder()
-                .setSigningKey(getSignInKey())
-                .build()
-                .parseClaimsJws(token)
-                .getBody();
-    }
-
-    private Key getSignInKey() {
-        byte[] keyBytes = Decoders.BASE64.decode(secretKey);
-        return Keys.hmacShaKeyFor(keyBytes);
     }
 }

--- a/services/user-service/src/main/java/com/github/matkubiak/taskplanner/service/JwtService.java
+++ b/services/user-service/src/main/java/com/github/matkubiak/taskplanner/service/JwtService.java
@@ -9,7 +9,6 @@
 package com.github.matkubiak.taskplanner.service;
 
 import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.io.Decoders;
 import java.util.Date;
 
@@ -38,12 +37,11 @@ public class JwtService {
     }
 
     public String generateToken(UserDetails userDetails) {
-        return Jwts
-                .builder()
-                .setSubject(userDetails.getUsername())
-                .setIssuedAt(new Date(System.currentTimeMillis()))
-                .setExpiration(new Date(System.currentTimeMillis() + jwtExpiration))
-                .signWith(secretKey, SignatureAlgorithm.HS256)
-                .compact();
+        return Jwts.builder()
+            .subject(userDetails.getUsername())
+            .issuedAt(new Date(System.currentTimeMillis()))
+            .expiration(new Date(System.currentTimeMillis() + jwtExpiration))
+            .signWith(secretKey)
+            .compact();
     }
 }


### PR DESCRIPTION
This PR updates JWT service to use a newer version of jjwt library and to include user id instead of email in the Subject field. This is handy, because now other microservices can get user id directly from the token. If this change was not introduced, they would have to request it from the user-service for each request or cache it.

### Changelog

API:
* JWT token's Subject field `sub` now stores user id instead of email
