### PR TITLE
Add missing year to copyright notice

### DIFF
--- a/gateway/src/main/java/com/github/matkubiak/taskplanner/gateway/JwtHttpException.java
+++ b/gateway/src/main/java/com/github/matkubiak/taskplanner/gateway/JwtHttpException.java
@@ -1,6 +1,6 @@
 /*
  * Task Planner
- * Copyright (C) Mateusz Kubiak
+ * Copyright (C) 2024 Mateusz Kubiak
  *
  * Licensed under the GNU General Public License v3.
  * See LICENSE or visit <https://www.gnu.org/licenses/>.

--- a/gateway/src/main/java/com/github/matkubiak/taskplanner/gateway/filters/JwtAuthorizationFilter.java
+++ b/gateway/src/main/java/com/github/matkubiak/taskplanner/gateway/filters/JwtAuthorizationFilter.java
@@ -1,6 +1,6 @@
 /*
  * Task Planner
- * Copyright (C) Mateusz Kubiak
+ * Copyright (C) 2024 Mateusz Kubiak
  *
  * Licensed under the GNU General Public License v3.
  * See LICENSE or visit <https://www.gnu.org/licenses/>.

--- a/gateway/src/main/java/com/github/matkubiak/taskplanner/gateway/service/JwtService.java
+++ b/gateway/src/main/java/com/github/matkubiak/taskplanner/gateway/service/JwtService.java
@@ -1,6 +1,6 @@
 /*
  * Task Planner
- * Copyright (C) Mateusz Kubiak
+ * Copyright (C) 2024 Mateusz Kubiak
  *
  * Licensed under the GNU General Public License v3.
  * See LICENSE or visit <https://www.gnu.org/licenses/>.

--- a/services/auth-service/src/main/java/com/github/matkubiak/taskplanner/config/ApplicationConfiguration.java
+++ b/services/auth-service/src/main/java/com/github/matkubiak/taskplanner/config/ApplicationConfiguration.java
@@ -1,6 +1,6 @@
 /*
  * Task Planner
- * Copyright (C) Mateusz Kubiak
+ * Copyright (C) 2024 Mateusz Kubiak
  *
  * Licensed under the GNU General Public License v3.
  * See LICENSE or visit <https://www.gnu.org/licenses/>.

--- a/services/auth-service/src/main/java/com/github/matkubiak/taskplanner/config/SecurityConfiguration.java
+++ b/services/auth-service/src/main/java/com/github/matkubiak/taskplanner/config/SecurityConfiguration.java
@@ -1,6 +1,6 @@
 /*
  * Task Planner
- * Copyright (C) Mateusz Kubiak
+ * Copyright (C) 2024 Mateusz Kubiak
  *
  * Licensed under the GNU General Public License v3.
  * See LICENSE or visit <https://www.gnu.org/licenses/>.

--- a/services/auth-service/src/main/java/com/github/matkubiak/taskplanner/controller/AuthenticationController.java
+++ b/services/auth-service/src/main/java/com/github/matkubiak/taskplanner/controller/AuthenticationController.java
@@ -1,6 +1,6 @@
 /*
  * Task Planner
- * Copyright (C) Mateusz Kubiak
+ * Copyright (C) 2024 Mateusz Kubiak
  *
  * Licensed under the GNU General Public License v3.
  * See LICENSE or visit <https://www.gnu.org/licenses/>.

--- a/services/auth-service/src/main/java/com/github/matkubiak/taskplanner/model/EmailMismatchException.java
+++ b/services/auth-service/src/main/java/com/github/matkubiak/taskplanner/model/EmailMismatchException.java
@@ -1,6 +1,6 @@
 /*
  * Task Planner
- * Copyright (C) Mateusz Kubiak
+ * Copyright (C) 2024 Mateusz Kubiak
  *
  * Licensed under the GNU General Public License v3.
  * See LICENSE or visit <https://www.gnu.org/licenses/>.

--- a/services/auth-service/src/main/java/com/github/matkubiak/taskplanner/model/ExtendedUserDetails.java
+++ b/services/auth-service/src/main/java/com/github/matkubiak/taskplanner/model/ExtendedUserDetails.java
@@ -1,6 +1,6 @@
 /*
  * Task Planner
- * Copyright (C) Mateusz Kubiak
+ * Copyright (C) 2024 Mateusz Kubiak
  *
  * Licensed under the GNU General Public License v3.
  * See LICENSE or visit <https://www.gnu.org/licenses/>.

--- a/services/auth-service/src/main/java/com/github/matkubiak/taskplanner/model/LoginDTO.java
+++ b/services/auth-service/src/main/java/com/github/matkubiak/taskplanner/model/LoginDTO.java
@@ -1,6 +1,6 @@
 /*
  * Task Planner
- * Copyright (C) Mateusz Kubiak
+ * Copyright (C) 2024 Mateusz Kubiak
  *
  * Licensed under the GNU General Public License v3.
  * See LICENSE or visit <https://www.gnu.org/licenses/>.

--- a/services/auth-service/src/main/java/com/github/matkubiak/taskplanner/model/LoginResponse.java
+++ b/services/auth-service/src/main/java/com/github/matkubiak/taskplanner/model/LoginResponse.java
@@ -1,6 +1,6 @@
 /*
  * Task Planner
- * Copyright (C) Mateusz Kubiak
+ * Copyright (C) 2024 Mateusz Kubiak
  *
  * Licensed under the GNU General Public License v3.
  * See LICENSE or visit <https://www.gnu.org/licenses/>.

--- a/services/auth-service/src/main/java/com/github/matkubiak/taskplanner/model/RegisterDTO.java
+++ b/services/auth-service/src/main/java/com/github/matkubiak/taskplanner/model/RegisterDTO.java
@@ -1,6 +1,6 @@
 /*
  * Task Planner
- * Copyright (C) Mateusz Kubiak
+ * Copyright (C) 2024 Mateusz Kubiak
  *
  * Licensed under the GNU General Public License v3.
  * See LICENSE or visit <https://www.gnu.org/licenses/>.

--- a/services/auth-service/src/main/java/com/github/matkubiak/taskplanner/model/User.java
+++ b/services/auth-service/src/main/java/com/github/matkubiak/taskplanner/model/User.java
@@ -1,6 +1,6 @@
 /*
  * Task Planner
- * Copyright (C) Mateusz Kubiak
+ * Copyright (C) 2024 Mateusz Kubiak
  *
  * Licensed under the GNU General Public License v3.
  * See LICENSE or visit <https://www.gnu.org/licenses/>.

--- a/services/auth-service/src/main/java/com/github/matkubiak/taskplanner/repository/UserRepository.java
+++ b/services/auth-service/src/main/java/com/github/matkubiak/taskplanner/repository/UserRepository.java
@@ -1,6 +1,6 @@
 /*
  * Task Planner
- * Copyright (C) Mateusz Kubiak
+ * Copyright (C) 2024 Mateusz Kubiak
  *
  * Licensed under the GNU General Public License v3.
  * See LICENSE or visit <https://www.gnu.org/licenses/>.

--- a/services/auth-service/src/main/java/com/github/matkubiak/taskplanner/service/AuthenticationService.java
+++ b/services/auth-service/src/main/java/com/github/matkubiak/taskplanner/service/AuthenticationService.java
@@ -1,6 +1,6 @@
 /*
  * Task Planner
- * Copyright (C) Mateusz Kubiak
+ * Copyright (C) 2024 Mateusz Kubiak
  *
  * Licensed under the GNU General Public License v3.
  * See LICENSE or visit <https://www.gnu.org/licenses/>.

--- a/services/auth-service/src/main/java/com/github/matkubiak/taskplanner/service/JwtService.java
+++ b/services/auth-service/src/main/java/com/github/matkubiak/taskplanner/service/JwtService.java
@@ -1,6 +1,6 @@
 /*
  * Task Planner
- * Copyright (C) Mateusz Kubiak
+ * Copyright (C) 2024 Mateusz Kubiak
  *
  * Licensed under the GNU General Public License v3.
  * See LICENSE or visit <https://www.gnu.org/licenses/>.


### PR DESCRIPTION
Copyright notice was outdated in some files and omited the project creation year. This PR resolves this issue.

instead of this:
```
Copyright (C) 2024 Mateusz Kubiak
```

the notice contained this:
```
Copyright (C) Mateusz Kubiak
```
