### PR TITLE
Fix conflicting exposed ports of docker containers

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,7 +37,7 @@ services:
   rabbitmq:
     image: rabbitmq:4.0-management-alpine
     ports:
-      - 8080:15672
+      - 8082:15672
     env_file: ./.env
     environment:
       - RABBITMQ_DEFAULT_USER=$RABBIT_USER
@@ -59,6 +59,7 @@ services:
   task-service:
     depends_on:
       - mysqldb
+      - rabbitmq
     build: ./services/task-service
     restart: on-failure
     env_file: ./.env
@@ -81,6 +82,7 @@ services:
   user-service:
     depends_on:
       - mysqldb
+      - rabbitmq
     build: ./services/user-service
     restart: on-failure
     env_file: ./.env


### PR DESCRIPTION
This PR fixes the conflict of exposed ports of docker containers, which was the effect of commit 92ad20ddc4af7a0c06c212d22ddbd3b5ff311d22. The commit exposed port 8080 of rabbitmq container, while the port 8080 was already exposed by the api gateway.

Changes in API:
* exposed port 8080 of rabbitmq container changed to 8082